### PR TITLE
Use valid Node.js package name (lowercase)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Technobabble Ipsum",
+  "name": "technobabble-ipsum",
   "main": "./lib/technobabble",
   "version": "0.3.0",
   "private": true,


### PR DESCRIPTION
This package cannot be installed from within Atom at the moment, the error thrown is:

```
npm ERR! addLocal Could not install /tmp/d-114420-11323-1dwbkum/package.tgz
npm ERR! Error: Invalid name: "Technobabble Ipsum"
npm ERR!     at ensureValidName (/usr/share/atom/resources/app/apm/node_modules/atom-package-manager/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/fixer.js:302:15)
npm ERR!     at Object.module.exports.fixNameField (/usr/share/atom/resources/app/apm/node_modules/atom-package-manager/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/fixer.js:206:5)
npm ERR!     at /usr/share/atom/resources/app/apm/node_modules/atom-package-manager/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/normalize.js:29:38
npm ERR!     at Array.forEach (native)
[…]
```

This pull request changes the name to the required format.
